### PR TITLE
Remove request validation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ run:
   timeout: '5m'
   skip-dirs:
     - '_examples'
+    - '_playground'
   allow-parallel-runners: true
   modules-download-mode: 'readonly'
 
@@ -9,7 +10,6 @@ linters:
   enable:
     - 'asciicheck'
     - 'bodyclose'
-    - 'depguard'
     - 'dogsled'
     - 'errcheck'
     - 'errorlint'

--- a/activity_log.go
+++ b/activity_log.go
@@ -25,7 +25,7 @@ type (
 
 	// ActivityLogGetOptions represents the query parameters for an activity log get request.
 	ActivityLogGetOptions struct {
-		ID string `url:"log" json:"-" validate:"required"` // ID is the unique identifier for the log object.
+		ID string `url:"log" json:"-"` // ID is the unique identifier for the log object.
 	}
 
 	// ActivityLogListResponse represents a response from the activity log list endpoint.

--- a/audit.go
+++ b/audit.go
@@ -45,7 +45,7 @@ type (
 
 	// AuditWorkplaceUserGetOptions represents options for the audit workplace user get endpoint.
 	AuditWorkplaceUserGetOptions struct {
-		UserID   string `url:"-" json:"-" validate:"required"`
+		UserID   string `url:"-" json:"-"`
 		Settings *bool  `url:"settings,omitempty" json:"-"` // If true, the api will return more information if the workplace has e.g. SAML enabled and SCIM enabled.
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -22,7 +22,7 @@ type (
 
 	// AuthRevokeOptions revokes an auth token.
 	AuthRevokeOptions struct {
-		Tokens []AuthToken `url:"-" json:"tokens" validate:"gt=0"` // A list of tokens to revoke.
+		Tokens []AuthToken `url:"-" json:"tokens"` // A list of tokens to revoke.
 	}
 )
 

--- a/config.go
+++ b/config.go
@@ -25,8 +25,8 @@ type (
 
 	// ConfigGetOptions represents the options for the config get endpoint.
 	ConfigGetOptions struct {
-		Project string `url:"project" json:"-" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"config" json:"-" validate:"required"`  // Name of the config.
+		Project string `url:"project" json:"-"` // Identifier of the project that the config belongs to.
+		Config  string `url:"config" json:"-"`  // Name of the config.
 	}
 
 	// ConfigListResponse represents a response from the config list endpoint.
@@ -42,7 +42,7 @@ type (
 	// ConfigListOptions represents the query parameters for a config list request.
 	ConfigListOptions struct {
 		ListOptions `url:",inline" json:"-"`
-		Project     string `url:"project" json:"-" validate:"required"` // Identifier of the project that the config belongs to.
+		Project     string `url:"project" json:"-"` // Identifier of the project that the config belongs to.
 	}
 
 	// ConfigCreateResponse represents a response from the config create endpoint.
@@ -57,9 +57,9 @@ type (
 
 	// ConfigCreateOptions represents the body parameters for a config create request.
 	ConfigCreateOptions struct {
-		Project     string `url:"-" json:"project" validate:"required"`     // Identifier of the project that the config belongs to.
-		Environment string `url:"-" json:"environment" validate:"required"` // Identifier of the environment that the config belongs to.
-		Name        string `url:"-" json:"name" validate:"required"`        // Name of the new branch configuration.
+		Project     string `url:"-" json:"project"`     // Identifier of the project that the config belongs to.
+		Environment string `url:"-" json:"environment"` // Identifier of the environment that the config belongs to.
+		Name        string `url:"-" json:"name"`        // Name of the new branch configuration.
 	}
 
 	// ConfigUpdateResponse represents a doppler config update request.
@@ -74,9 +74,9 @@ type (
 
 	// ConfigUpdateOptions represents the body parameters for a config update request.
 	ConfigUpdateOptions struct {
-		Project string `url:"-" json:"project" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"-" json:"config" validate:"required"`  // Name of the config.
-		NewName string `url:"-" json:"name" validate:"required"`    // New name of the config.
+		Project string `url:"-" json:"project"` // Identifier of the project that the config belongs to.
+		Config  string `url:"-" json:"config"`  // Name of the config.
+		NewName string `url:"-" json:"name"`    // New name of the config.
 	}
 
 	// ConfigDeleteResponse represents a response from the config delete endpoint.
@@ -90,8 +90,8 @@ type (
 
 	// ConfigDeleteOptions represents the body parameters for a config delete request.
 	ConfigDeleteOptions struct {
-		Project string `url:"-" json:"project" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"-" json:"config" validate:"required"`  // Name of the config.
+		Project string `url:"-" json:"project"` // Identifier of the project that the config belongs to.
+		Config  string `url:"-" json:"config"`  // Name of the config.
 	}
 
 	// ConfigLockResponse represents a response from the config lock endpoint.
@@ -106,8 +106,8 @@ type (
 
 	// ConfigLockOptions represents the body parameters for a config lock request.
 	ConfigLockOptions struct {
-		Project string `url:"-" json:"project" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"-" json:"config" validate:"required"`  // Name of the config.
+		Project string `url:"-" json:"project"` // Identifier of the project that the config belongs to.
+		Config  string `url:"-" json:"config"`  // Name of the config.
 	}
 
 	// ConfigUnlockResponse represents a response from the config unlock endpoint.
@@ -122,8 +122,8 @@ type (
 
 	// ConfigUnlockOptions represents the body parameters for a config unlock request.
 	ConfigUnlockOptions struct {
-		Project string `url:"-" json:"project" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"-" json:"config" validate:"required"`  // Name of the config.
+		Project string `url:"-" json:"project"` // Identifier of the project that the config belongs to.
+		Config  string `url:"-" json:"config"`  // Name of the config.
 	}
 
 	// ConfigCloneResponse represents a response from the config clone endpoint.
@@ -138,8 +138,8 @@ type (
 
 	// ConfigCloneOptions represents the body parameters for a config clone request.
 	ConfigCloneOptions struct {
-		Project   string `url:"-" json:"project" validate:"required"` // Identifier of the project that the config belongs to.
-		Config    string `url:"-" json:"config" validate:"required"`  // Name of the config.
-		NewConfig string `url:"-" json:"name" validate:"required"`    // Name of the new config.
+		Project   string `url:"-" json:"project"` // Identifier of the project that the config belongs to.
+		Config    string `url:"-" json:"config"`  // Name of the config.
+		NewConfig string `url:"-" json:"name"`    // Name of the new config.
 	}
 )

--- a/config_log.go
+++ b/config_log.go
@@ -33,9 +33,9 @@ type (
 
 	// ConfigLogGetOptions represents the options for the config log get endpoint.
 	ConfigLogGetOptions struct {
-		Project string `url:"project" json:"-" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"config" json:"-" validate:"required"`  // Name of the config.
-		ID      string `url:"log" json:"-" validate:"required"`     // Unique identifier of the config log.
+		Project string `url:"project" json:"-"` // Identifier of the project that the config belongs to.
+		Config  string `url:"config" json:"-"`  // Name of the config.
+		ID      string `url:"log" json:"-"`     // Unique identifier of the config log.
 	}
 
 	// ConfigLogListResponse represents a response from the config log list endpoint.
@@ -51,8 +51,8 @@ type (
 	// ConfigLogListOptions represents the query parameters for a config log list request.
 	ConfigLogListOptions struct {
 		ListOptions `url:",inline" json:"-"`
-		Project     string `url:"project" json:"-" validate:"required"` // Identifier of the project that the config belongs to.
-		Config      string `url:"config" json:"-" validate:"required"`  // Name of the config.
+		Project     string `url:"project" json:"-"` // Identifier of the project that the config belongs to.
+		Config      string `url:"config" json:"-"`  // Name of the config.
 	}
 
 	// ConfigLogRollbackResponse represents a response from the config log rollback endpoint.
@@ -67,8 +67,8 @@ type (
 
 	// ConfigLogRollbackOptions represents the options for the config log rollback endpoint.
 	ConfigLogRollbackOptions struct {
-		Project string `url:"project" json:"-" validate:"required"` // Identifier of the project that the config belongs to.
-		Config  string `url:"config" json:"-" validate:"required"`  // Name of the config.
-		ID      string `url:"log" json:"-" validate:"required"`     // Unique identifier of the config log.
+		Project string `url:"project" json:"-"` // Identifier of the project that the config belongs to.
+		Config  string `url:"config" json:"-"`  // Name of the config.
+		ID      string `url:"log" json:"-"`     // Unique identifier of the config log.
 	}
 )

--- a/doppler.go
+++ b/doppler.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/go-playground/validator/v10"
-
 	"github.com/nikoksr/doppler-go/logging"
 	"github.com/nikoksr/doppler-go/pointer"
 )
@@ -48,15 +46,6 @@ const (
 
 // Key is the API key used to authenticate with the API
 var Key string
-
-// EnableValidation enables validation of the payload. This is enabled by default. If you want to disable validation,
-// set this to false.
-var EnableValidation = true
-
-// Internal standard logger and validator.
-var (
-	stdValidator = validator.New()
-)
 
 // BackendConfig is the configuration for the backend.
 type BackendConfig struct {
@@ -303,25 +292,9 @@ func (req *Request) getBody() (*bytes.Buffer, error) {
 	return encodedBody, nil
 }
 
-// isPayloadValid uses the go-playground validator to validate the payload. It is expected that the payload is a struct
-// and validation tags are used to define the validation rules. Using this function to make the code more readable.
-// Validation is skipped if EnableValidation is false or the payload is nil.
-func isPayloadValid(payload any) error {
-	if !EnableValidation || payload == nil {
-		return nil
-	}
-
-	return stdValidator.Struct(payload)
-}
-
 // prepareRequest creates a new HTTP request from the given Request. The returned request is ready to be sent to the
 // API.
 func (b *backendImplementation) prepareRequest(ctx context.Context, req *Request) (*http.Request, error) {
-	// Validate the request's payload before we do anything else.
-	if err := isPayloadValid(req.Payload); err != nil {
-		return nil, errors.Wrap(err, "validate request payload")
-	}
-
 	// Normalize URL
 	if !strings.HasPrefix(req.Path, "/") {
 		req.Path = "/" + req.Path

--- a/doppler.go
+++ b/doppler.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// SDKVersion is the version of the SDK
-	SDKVersion = "0.2.0"
+	SDKVersion = "0.2.1"
 
 	// APIURL is the base URL for the API
 	APIURL string = "https://api.doppler.com"

--- a/doppler_test.go
+++ b/doppler_test.go
@@ -522,31 +522,6 @@ func Test_normalizeURL(t *testing.T) {
 	}
 }
 
-func Test_isPayloadValid(t *testing.T) {
-	t.Parallel()
-
-	// First, test a nil payload.
-	if err := isPayloadValid(nil); err != nil {
-		t.Fatalf("isPayloadValid(nil) returned an error: %v", err)
-	}
-
-	// Test a valid payload. All three fields of SecretGetOptions are required. The validator should not return an error.
-	getOptions := &SecretGetOptions{
-		Project: "fake-project",
-		Config:  "fake-config",
-		Name:    "fake-name",
-	}
-	if err := isPayloadValid(getOptions); err != nil {
-		t.Fatalf("isPayloadValid() returned an error: %v", err)
-	}
-
-	// Now, remove the project field. The validator should return an error.
-	getOptions.Project = ""
-	if err := isPayloadValid(getOptions); err == nil {
-		t.Fatal("isPayloadValid() should return an error")
-	}
-}
-
 func Test_Call(t *testing.T) {
 	t.Parallel()
 

--- a/dynamic_secret.go
+++ b/dynamic_secret.go
@@ -12,10 +12,10 @@ type (
 
 	// DynamicSecretIssueLeaseOptions represents the options for the dynamic secret issue lease endpoint.
 	DynamicSecretIssueLeaseOptions struct {
-		Project    string `url:"-" json:"project" validate:"required"`        // The project where the dynamic secret is located
-		Config     string `url:"-" json:"config" validate:"required"`         // The config where the dynamic secret is located
-		Name       string `url:"-" json:"dynamic_secret" validate:"required"` // The dynamic secret to issue a lease for
-		TTLSeconds int32  `url:"-" json:"ttl_seconds" validate:"required"`    // The number of seconds the lease should last
+		Project    string `url:"-" json:"project"`        // The project where the dynamic secret is located
+		Config     string `url:"-" json:"config"`         // The config where the dynamic secret is located
+		Name       string `url:"-" json:"dynamic_secret"` // The dynamic secret to issue a lease for
+		TTLSeconds int32  `url:"-" json:"ttl_seconds"`    // The number of seconds the lease should last
 	}
 
 	// DynamicSecretRevokeLeaseResponse represents a response from the dynamic secret revoke lease endpoint.
@@ -29,9 +29,9 @@ type (
 
 	// DynamicSecretRevokeLeaseOptions represents the options for the dynamic secret revoke lease endpoint.
 	DynamicSecretRevokeLeaseOptions struct {
-		Project string `url:"-" json:"project" validate:"required"`        // The project where the dynamic secret is located
-		Config  string `url:"-" json:"config" validate:"required"`         // The config where the dynamic secret is located
-		Name    string `url:"-" json:"dynamic_secret" validate:"required"` // The dynamic secret to revoke a lease for
-		Slug    string `url:"-" json:"slug" validate:"required"`           // The lease to revoke
+		Project string `url:"-" json:"project"`        // The project where the dynamic secret is located
+		Config  string `url:"-" json:"config"`         // The config where the dynamic secret is located
+		Name    string `url:"-" json:"dynamic_secret"` // The dynamic secret to revoke a lease for
+		Slug    string `url:"-" json:"slug"`           // The lease to revoke
 	}
 )

--- a/environment.go
+++ b/environment.go
@@ -23,8 +23,8 @@ type (
 
 	// EnvironmentGetOptions represents the options for the environment get endpoint.
 	EnvironmentGetOptions struct {
-		Project string `url:"project" json:"-" validate:"required"`     // Identifier of the project the environment belongs to.
-		Slug    string `url:"environment" json:"-" validate:"required"` // A unique identifier for the environment.
+		Project string `url:"project" json:"-"`     // Identifier of the project the environment belongs to.
+		Slug    string `url:"environment" json:"-"` // A unique identifier for the environment.
 	}
 
 	// EnvironmentListResponse represents a response from the environment list endpoint.
@@ -39,7 +39,7 @@ type (
 
 	// EnvironmentListOptions represents the query parameters for a environment list request.
 	EnvironmentListOptions struct {
-		Project string `url:"project" json:"-" validate:"required"` // Identifier of the project the environment belongs to.
+		Project string `url:"project" json:"-"` // Identifier of the project the environment belongs to.
 	}
 
 	// EnvironmentCreateResponse represents a response from the environment create endpoint.
@@ -54,9 +54,9 @@ type (
 
 	// EnvironmentCreateOptions represents the body parameters for a environment create request.
 	EnvironmentCreateOptions struct {
-		Project string `url:"project" json:"-" validate:"required"`        // Identifier of the project the environment belongs to.
-		Name    string `url:"-" json:"name,omitempty" validate:"required"` // Name of the environment.
-		Slug    string `url:"-" json:"slug,omitempty" validate:"required"` // A unique identifier for the environment.
+		Project string `url:"project" json:"-"`        // Identifier of the project the environment belongs to.
+		Name    string `url:"-" json:"name,omitempty"` // Name of the environment.
+		Slug    string `url:"-" json:"slug,omitempty"` // A unique identifier for the environment.
 	}
 
 	// EnvironmentRenameResponse represents a doppler environment rename request.
@@ -71,10 +71,10 @@ type (
 
 	// EnvironmentRenameOptions represents the body parameters for a environment rename request.
 	EnvironmentRenameOptions struct {
-		Project string  `url:"project" json:"-" validate:"required"`     // Identifier of the project the environment belongs to.
-		Slug    string  `url:"environment" json:"-" validate:"required"` // A unique identifier for the environment.
-		NewName *string `url:"-" json:"name,omitempty"`                  // New name of the environment.
-		NewSlug *string `url:"-" json:"slug,omitempty"`                  // New slug of the environment.
+		Project string  `url:"project" json:"-"`        // Identifier of the project the environment belongs to.
+		Slug    string  `url:"environment" json:"-"`    // A unique identifier for the environment.
+		NewName *string `url:"-" json:"name,omitempty"` // New name of the environment.
+		NewSlug *string `url:"-" json:"slug,omitempty"` // New slug of the environment.
 	}
 
 	// EnvironmentDeleteResponse represents a response from the environment delete endpoint.
@@ -88,7 +88,7 @@ type (
 
 	// EnvironmentDeleteOptions represents the body parameters for a environment delete request.
 	EnvironmentDeleteOptions struct {
-		Project string `url:"project" json:"-" validate:"required"`     // Identifier of the project the environment belongs to.
-		Slug    string `url:"environment" json:"-" validate:"required"` // A unique identifier for the environment.
+		Project string `url:"project" json:"-"`     // Identifier of the project the environment belongs to.
+		Slug    string `url:"environment" json:"-"` // A unique identifier for the environment.
 	}
 )

--- a/project.go
+++ b/project.go
@@ -22,7 +22,7 @@ type (
 
 	// ProjectGetOptions represents the options for the project get endpoint.
 	ProjectGetOptions struct {
-		Name string `url:"project" json:"-" validate:"required"` // Name is the name of the project.
+		Name string `url:"project" json:"-"` // Name is the name of the project.
 	}
 
 	// ProjectListResponse represents a response from the project list endpoint.
@@ -52,8 +52,8 @@ type (
 
 	// ProjectCreateOptions represents the body parameters for a project create request.
 	ProjectCreateOptions struct {
-		Name        string  `url:"-" json:"name" validate:"required"` // Name of the project.
-		Description *string `url:"-" json:"description,omitempty"`    // Description of the project.
+		Name        string  `url:"-" json:"name"`                  // Name of the project.
+		Description *string `url:"-" json:"description,omitempty"` // Description of the project.
 	}
 
 	// ProjectUpdateResponse represents a doppler project update request.
@@ -68,9 +68,9 @@ type (
 
 	// ProjectUpdateOptions represents the body parameters for a project update request.
 	ProjectUpdateOptions struct {
-		Name           string  `url:"-" json:"project" validate:"required"`        // Name of the project.
-		NewName        string  `url:"-" json:"name,omitempty" validate:"required"` // New name of the project.
-		NewDescription *string `url:"-" json:"description,omitempty"`              // New description of the project.
+		Name           string  `url:"-" json:"project"`               // Name of the project.
+		NewName        string  `url:"-" json:"name,omitempty"`        // New name of the project.
+		NewDescription *string `url:"-" json:"description,omitempty"` // New description of the project.
 	}
 
 	// ProjectDeleteResponse represents a response from the project delete endpoint.
@@ -84,6 +84,6 @@ type (
 
 	// ProjectDeleteOptions represents the body parameters for a project delete request.
 	ProjectDeleteOptions struct {
-		Name string `url:"-" json:"project" validate:"required"` // Name of the project.
+		Name string `url:"-" json:"project"` // Name of the project.
 	}
 )

--- a/secret.go
+++ b/secret.go
@@ -25,9 +25,9 @@ type (
 
 	// SecretGetOptions represents options for the secrets get endpoint.
 	SecretGetOptions struct {
-		Project string `url:"project" json:"-" validate:"required"` // The name of the project containing the secret.
-		Config  string `url:"config" json:"-" validate:"required"`  // The name of the config containing the secret.
-		Name    string `url:"name" json:"-" validate:"required"`    // The name of the secret.
+		Project string `url:"project" json:"-"` // The name of the project containing the secret.
+		Config  string `url:"config" json:"-"`  // The name of the config containing the secret.
+		Name    string `url:"name" json:"-"`    // The name of the secret.
 	}
 
 	// SecretListResponse represents a response from the secrets list endpoint.
@@ -42,8 +42,8 @@ type (
 
 	// SecretListOptions represents options for the secrets list endpoint.
 	SecretListOptions struct {
-		Project           string  `url:"project" json:"-" validate:"required"`       // The name of the project containing the secret.
-		Config            string  `url:"config" json:"-" validate:"required"`        // The name of the config containing the secret.
+		Project           string  `url:"project" json:"-"`                           // The name of the project containing the secret.
+		Config            string  `url:"config" json:"-"`                            // The name of the config containing the secret.
 		IncludeDynamic    *bool   `url:"include_dynamic_secrets,omitempty" json:"-"` // Whether to include dynamic secrets.
 		DynamicTTLSeconds *int32  `url:"dynamic_secrets_ttl_sec,omitempty" json:"-"` // The number of seconds until dynamic leases expire. Must be used with include_dynamic_secrets.
 		Secrets           *string `url:"secrets,omitempty" json:"-"`                 // A comma-separated list of secret names to include.
@@ -61,9 +61,9 @@ type (
 
 	// SecretUpdateOptions represents options for the secrets update endpoint.
 	SecretUpdateOptions struct {
-		Project    string            `url:"-" json:"project" validate:"required"`           // The name of the project containing the secret.
-		Config     string            `url:"-" json:"config" validate:"required"`            // The name of the config containing the secret.
-		NewSecrets map[string]string `url:"-" json:"secrets" validate:"gt=0,dive,required"` // The secrets to update.
+		Project    string            `url:"-" json:"project"` // The name of the project containing the secret.
+		Config     string            `url:"-" json:"config"`  // The name of the config containing the secret.
+		NewSecrets map[string]string `url:"-" json:"secrets"` // The secrets to update.
 	}
 
 	// SecretDownloadOptions represents options for the secrets download endpoint.
@@ -72,8 +72,8 @@ type (
 	// Endpoint: https://api.doppler.com/v3/configs/config/secrets/download
 	// Docs:     https://docs.doppler.com/reference/config-secret-download
 	SecretDownloadOptions struct {
-		Project           string  `url:"project" json:"-" validate:"required"`       // The name of the project containing the secret.
-		Config            string  `url:"config" json:"-" validate:"required"`        // The name of the config containing the secret.
+		Project           string  `url:"project" json:"-"`                           // The name of the project containing the secret.
+		Config            string  `url:"config" json:"-"`                            // The name of the config containing the secret.
 		IncludeDynamic    *bool   `url:"include_dynamic_secrets,omitempty" json:"-"` // Whether to include dynamic secrets.
 		DynamicTTLSeconds *int32  `url:"dynamic_secrets_ttl_sec,omitempty" json:"-"` // The number of seconds until dynamic leases expire. Must be used with include_dynamic_secrets.
 		Format            *string `url:"format,omitempty" json:"-"`                  // The format to download the secrets in. See official docs for supported formats.

--- a/service_token.go
+++ b/service_token.go
@@ -26,8 +26,8 @@ type (
 
 	// ServiceTokenListOptions represents the options for the service-token list endpoint.
 	ServiceTokenListOptions struct {
-		Project string `url:"project,omitempty" json:"-" validate:"required"` // Unique identifier for the project object.
-		Config  string `url:"config,omitempty" json:"-" validate:"required"`  // The config's name.
+		Project string `url:"project,omitempty" json:"-"` // Unique identifier for the project object.
+		Config  string `url:"config,omitempty" json:"-"`  // The config's name.
 	}
 
 	// ServiceTokenCreateResponse represents a response from the service-token create endpoint.
@@ -42,11 +42,11 @@ type (
 
 	// ServiceTokenCreateOptions represents the options for the service-token create endpoint.
 	ServiceTokenCreateOptions struct {
-		Project   string  `url:"-" json:"project,omitempty" validate:"required"` // Unique identifier for the project object.
-		Config    string  `url:"-" json:"config,omitempty" validate:"required"`  // The config's name.
-		Name      string  `url:"-" json:"name,omitempty" validate:"required"`    // Name of the service token.
-		Access    *string `url:"-" json:"access,omitempty"`                      // The access level of the service token. One of read, read/write.
-		ExpiresAt *string `url:"-" json:"expires_at,omitempty"`                  // Date and time of the token's expiration, or null if token does not auto-expire.
+		Project   string  `url:"-" json:"project,omitempty"`    // Unique identifier for the project object.
+		Config    string  `url:"-" json:"config,omitempty"`     // The config's name.
+		Name      string  `url:"-" json:"name,omitempty"`       // Name of the service token.
+		Access    *string `url:"-" json:"access,omitempty"`     // The access level of the service token. One of read, read/write.
+		ExpiresAt *string `url:"-" json:"expires_at,omitempty"` // Date and time of the token's expiration, or null if token does not auto-expire.
 	}
 
 	// ServiceTokenDeleteResponse represents a response from the service-token delete endpoint.
@@ -60,8 +60,8 @@ type (
 
 	// ServiceTokenDeleteOptions represents the options for the service-token delete endpoint.
 	ServiceTokenDeleteOptions struct {
-		Project string `url:"-" json:"project,omitempty" validate:"required"` // Unique identifier for the project object.
-		Config  string `url:"-" json:"config,omitempty" validate:"required"`  // The config's name.
-		Slug    string `url:"-" json:"slug,omitempty" validate:"required"`    // A unique identifier of the service token.
+		Project string `url:"-" json:"project,omitempty"` // Unique identifier for the project object.
+		Config  string `url:"-" json:"config,omitempty"`  // The config's name.
+		Slug    string `url:"-" json:"slug,omitempty"`    // A unique identifier of the service token.
 	}
 )

--- a/service_token/client.go
+++ b/service_token/client.go
@@ -65,7 +65,7 @@ func Create(ctx context.Context, opts *doppler.ServiceTokenCreateOptions) (*dopp
 	return Default().Create(ctx, opts)
 }
 
-func (c Client) delete(ctx context.Context, opts *doppler.ServiceTokenDeleteOptions) (doppler.APIResponse, error) {
+func (c Client) delete(ctx context.Context, _ *doppler.ServiceTokenDeleteOptions) (doppler.APIResponse, error) {
 	var resp doppler.ServiceTokenDeleteResponse
 	err := c.Backend.Call(ctx, &doppler.Request{
 		Method: http.MethodDelete,

--- a/share.go
+++ b/share.go
@@ -25,9 +25,9 @@ type (
 
 	// SharePlainOptions represents the options for the share plain endpoint.
 	SharePlainOptions struct {
-		Secret      string `url:"-" json:"secret" validate:"required"` // Plain text secret to share.
-		ExpireViews *int32 `url:"-" json:"expire_views,omitempty"`     // Number of views before the link expires. Valid ranges: 1 to 50. -1 for unlimited.
-		ExpireDays  *int32 `url:"-" json:"expire_days,omitempty"`      // Number of days before the link expires. Valid range: 1 to 90.
+		Secret      string `url:"-" json:"secret"`                 // Plain text secret to share.
+		ExpireViews *int32 `url:"-" json:"expire_views,omitempty"` // Number of views before the link expires. Valid ranges: 1 to 50. -1 for unlimited.
+		ExpireDays  *int32 `url:"-" json:"expire_days,omitempty"`  // Number of days before the link expires. Valid range: 1 to 90.
 	}
 
 	// ShareEncryptedResponse represents a response from the share encrypted endpoint.
@@ -42,12 +42,12 @@ type (
 
 	// ShareEncryptedOptions represents the options for the share encrypted endpoint.
 	ShareEncryptedOptions struct {
-		Secret      string `url:"-" json:"encrypted_secret" validate:"required"`                 // Base64 encoded AES-GCM encrypted secret to share. See docs for more details.
-		Password    string `url:"-" json:"hashed_password" validate:"required"`                  // SHA256 hash of the password. This is NOT the hash of the derived encryption key.
-		KDF         string `url:"-" json:"encryption_kdf" validate:"required,eq=pbkdf2"`         // The key derivation function used. Must by "pbkdf2".
-		SaltRounds  int32  `url:"-" json:"encryption_salt_rounds" validate:"required,eq=100000"` // Number of salt rounds used by KDF. Must be "100000".
-		ExpireViews *int32 `url:"-" json:"expire_views,omitempty"`                               // Number of views before the link expires. Valid ranges: 1 to 50. -1 for unlimited.
-		ExpireDays  *int32 `url:"-" json:"expire_days,omitempty"`                                // Number of days before the link expires. Valid range: 1 to 90.
+		Secret      string `url:"-" json:"encrypted_secret"`       // Base64 encoded AES-GCM encrypted secret to share. See docs for more details.
+		Password    string `url:"-" json:"hashed_password"`        // SHA256 hash of the password. This is NOT the hash of the derived encryption key.
+		KDF         string `url:"-" json:"encryption_kdf"`         // The key derivation function used. Must by "pbkdf2".
+		SaltRounds  int32  `url:"-" json:"encryption_salt_rounds"` // Number of salt rounds used by KDF. Must be "100000".
+		ExpireViews *int32 `url:"-" json:"expire_views,omitempty"` // Number of views before the link expires. Valid ranges: 1 to 50. -1 for unlimited.
+		ExpireDays  *int32 `url:"-" json:"expire_days,omitempty"`  // Number of days before the link expires. Valid range: 1 to 90.
 	}
 )
 


### PR DESCRIPTION
### Summary

Removing request validation from the core package. The manual validation was intended to take stress from the API. However, it takes too much effort to keep up with such atomic changes in the API. Leaving it to the API to do the validation. This cleans up the code and makes it more flexible in the future.